### PR TITLE
test: stabilize machine-dependent integration and hypothesis flakes

### DIFF
--- a/tests/contracts/internal/ops/test_dag_ops_contract.py
+++ b/tests/contracts/internal/ops/test_dag_ops_contract.py
@@ -127,6 +127,7 @@ class TestDagOps:
                         txn.delete(ref)
 
     @given(_dag_strategy().filter(lambda d: d.is_finished()), st.text(alphabet=REF_ALPHABET, min_size=1, max_size=16))
+    @settings(deadline=None)
     def test_get_node_not_found_raises(self, temp_bo, dag, name):
         """get_node should raise if the named node is not present."""
         assume(name not in dag.names)

--- a/tests/integration/contrib/test_funkify_integration.py
+++ b/tests/integration/contrib/test_funkify_integration.py
@@ -107,7 +107,8 @@ def _poll_until_terminal(
 ) -> dict[str, Any]:
     execution_id = f"exec-{cache_key}"
     state: dict[str, Any] | None = initial_state
-    for _ in range(200):
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
         result = LocalAdapter.send(
             runnable=runnable,
             argv_ptr=argv_ptr,
@@ -123,7 +124,7 @@ def _poll_until_terminal(
         if result["status"] in {"succeeded", "failed"}:
             return cast(dict[str, Any], result)
         time.sleep(0.01)
-    pytest.fail("script executor did not reach terminal state")
+    pytest.fail("script executor did not reach terminal state within 5.0s")
 
 
 def test_funkify_decorator_returns_delayed_runnable():

--- a/tests/integration/contrib/test_local_runtime_integration.py
+++ b/tests/integration/contrib/test_local_runtime_integration.py
@@ -72,7 +72,8 @@ def _poll_until_terminal(
 ) -> dict[str, Any]:
     execution_id = f"exec-{cache_key}"
     state: dict[str, Any] | None = initial_state
-    for _ in range(200):
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
         result = LocalAdapter.send(
             runnable=runnable,
             argv_ptr=argv_ptr,
@@ -88,7 +89,7 @@ def _poll_until_terminal(
         if result["status"] in {"succeeded", "failed"}:
             return cast(dict[str, Any], result)
         time.sleep(0.01)
-    pytest.fail("script executor did not reach terminal state")
+    pytest.fail("script executor did not reach terminal state within 5.0s")
 
 
 def _mk_script_runnable(script: str, *, fn_name: str = "fn", call_kwargs: dict[str, Any] | None = None) -> Runnable:

--- a/tests/integration/internal/ops/test_commit_integration.py
+++ b/tests/integration/internal/ops/test_commit_integration.py
@@ -392,7 +392,7 @@ class TestCommitOps:
         assert "target" in rebased_tree.dags  # Target base included
 
     @given(st.lists(_tree_strategy(), min_size=2, max_size=5))
-    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
     def test_multiple_commits_hypothesis(self, ops, tree_objs):
         """Test creating and listing multiple commits with hypothesis."""
         ops, _ = ops
@@ -457,7 +457,7 @@ class TestCommitOps:
         _commit_strategy(),
         _tree_strategy(),
     )
-    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
     def test_merge_real(self, ops, c0, t0, c1, t1, c2, t2):
         """Test merge with hypothesis-generated commits."""
         ops, _ = ops


### PR DESCRIPTION
Broaden two script-executor integration polling helpers from a fixed ~2.0s budget to a 5.0s monotonic deadline so terminal-state polling no longer flakes on slower machines during full-suite runs.

Also disable Hypothesis deadlines on three property tests that were failing with DeadlineExceeded/FlakyFailure under full-suite runtime conditions despite passing on rerun. These are timing-related test stabilizations only; no runtime code or public behavior changed.

Changes:
- use time.monotonic() + 5.0 in contrib lifecycle polling helpers
- clarify the contrib timeout failure message
- add deadline=None to the three flaky Hypothesis tests

Verification performed before commit:
- targeted contrib lifecycle repros
- broader contrib runtime/integration tests
- full pytest suite: 656 passed, 7 warnings
- compact quality gate: tests/lint/pyright all passing